### PR TITLE
Fix: Updates Available badge fade-in in Title Screen

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/SmallModMenuButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/SmallModMenuButtonWidget.java
@@ -37,8 +37,8 @@ public class SmallModMenuButtonWidget extends SpriteIconButton.CenteredIcon {
     @Override
     public void extractContents(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
         super.extractContents(drawContext, mouseX, mouseY, delta);
-        if (ModMenuConfig.BUTTON_UPDATE_BADGE.getValue() && ModMenu.areModUpdatesAvailable() && getAlpha() >= 1.0f) {
-            UpdateAvailableBadge.renderBadge(drawContext, this.getX() + this.width - 5, this.getY() - 3);
+        if (ModMenuConfig.BUTTON_UPDATE_BADGE.getValue() && ModMenu.areModUpdatesAvailable()) {
+            UpdateAvailableBadge.renderBadge(drawContext, this.getX() + this.width - 5, this.getY() - 3, getAlpha());
         }
     }
 }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
@@ -10,7 +10,7 @@ public class UpdateAvailableBadge {
     private static final Identifier UPDATE_ICON = Identifier.withDefaultNamespace("icon/trial_available");
 
     public static void renderBadge(GuiGraphicsExtractor drawContext, int x, int y) {
-        renderBadge(drawContext, x, y, 0xFF);
+        renderBadge(drawContext, x, y, 1.0F);
     }
 
     public static void renderBadge(GuiGraphicsExtractor drawContext, int x, int y, float alpha) {

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
@@ -6,7 +6,6 @@ import net.minecraft.resources.Identifier;
 import static java.lang.Math.round;
 import static java.lang.Math.clamp;
 
-
 public class UpdateAvailableBadge {
     private static final Identifier UPDATE_ICON = Identifier.withDefaultNamespace("icon/trial_available");
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
@@ -3,11 +3,22 @@ package com.terraformersmc.modmenu.gui.widget;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
+import static java.lang.Math.round;
+import static java.lang.Math.clamp;
+
 
 public class UpdateAvailableBadge {
     private static final Identifier UPDATE_ICON = Identifier.withDefaultNamespace("icon/trial_available");
 
     public static void renderBadge(GuiGraphicsExtractor drawContext, int x, int y) {
-        drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, UPDATE_ICON, x, y, 8, 8, 0xFFFFFFFF);
+        renderBadge(drawContext, x, y, 0xFF);
     }
+
+    public static void renderBadge(GuiGraphicsExtractor drawContext, int x, int y, float alpha) {
+        int alphaByte = round(clamp(alpha, 0.0F, 1.0F) * 255.0F);
+        int color = (alphaByte << 24) | 0x00FFFFFF;
+        drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, UPDATE_ICON, x, y, 8, 8, color);
+    }
+
+
 }


### PR DESCRIPTION
This PR provides a quick fix of a small UI/UX issue I found while using the mod.

Currently, `updates available` badge is not following fade-in of the title screen when Minecraft starts up - in previous versions, it was appearing there *before* the title screen did, and now it appears *after* the title screen, ignoring its alpha channel all together, and, as a result - ignoring title screen's fade-in.

This PR aims to fix that problem.

- Before:
![before](https://github.com/user-attachments/assets/d2e240d9-2bef-442c-935b-07550666d5e6)

- After:
![after](https://github.com/user-attachments/assets/df5c84bd-1940-4978-b84a-2fb68d81540a)